### PR TITLE
add peer dependency on @types/better-sqlite3

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "mkdirp": "^1.0.4"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.3",
     "chai": "^4.2.0",
     "cross-env": "^7.0.3",
     "eslint": "^8.1.0",
@@ -35,7 +36,7 @@
     "mocha": "^9.1.3"
   },
   "peerDependencies": {
-    "@types/better-sqlite3": "^7.4.0"
+    "@types/better-sqlite3": "^7.6.3"
   },
   "peerDependenciesMeta": {
     "@types/better-sqlite3": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,14 @@
     "eslint-plugin-promise": "^5.1.1",
     "mocha": "^9.1.3"
   },
+  "peerDependencies": {
+    "@types/better-sqlite3": "^7.4.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/better-sqlite3": {
+      "optional": true
+    }
+  },
   "optionalDependencies": {
     "app-root-path": "^3.0.0"
   }


### PR DESCRIPTION
The type definition of better-sqlite3 is referenced in [`index.d.ts` of this package](https://github.com/Kauto/better-sqlite3-helper/blob/master/index.d.ts#L1)