### PR TITLE
patch: add type signature for creating new instance of DB

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -300,3 +300,7 @@ declare namespace BetterSqlite3Helper {
 export default function DB(
   options?: BetterSqlite3Helper.DBOptions
 ): BetterSqlite3Helper.DBInstance;
+
+export default class DB {
+  constructor(options?: BetterSqlite3Helper.DBOptions)
+}


### PR DESCRIPTION
This fixes the typescript error when creating new DB instance with `new` statement.