### PR TITLE
patch: skip setting default dbFile as path when the DB is in-memory

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -33,7 +33,7 @@ function DB (options = {}) {
   }
   this.options = Object.assign(
     {
-      path: dbFile,
+      path: options.memory ? ':memory:' : dbFile,
       migrate: true,
       readonly: false,
       fileMustExist: false,


### PR DESCRIPTION
otherwise, it will connect to the file instead of keeping in-memory